### PR TITLE
Fix type-checking errors in scraper, browser, and sheets

### DIFF
--- a/polla_app/browser.py
+++ b/polla_app/browser.py
@@ -2,8 +2,16 @@
 
 import logging
 from pathlib import Path
+from types import TracebackType
 
-from playwright.async_api import Browser, BrowserContext, Page, Playwright, async_playwright
+from playwright.async_api import (
+    Browser,
+    BrowserContext,
+    Page,
+    Playwright,
+    Response,
+    async_playwright,
+)
 
 from .config import AppConfig
 from .exceptions import ScriptError
@@ -26,7 +34,12 @@ class PlaywrightManager:
         await self._initialize()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Async context manager exit."""
         await self.close()
 
@@ -68,7 +81,7 @@ class PlaywrightManager:
         except Exception as e:
             raise ScriptError("Failed to initialize browser", e, "BROWSER_INIT_ERROR") from e
 
-    def _log_response(self, response) -> None:
+    def _log_response(self, response: Response) -> None:
         """Log interesting responses for debugging."""
         if response.status >= 400:
             self.logger.warning("HTTP %d response from %s", response.status, response.url[:100])

--- a/polla_app/scraper.py
+++ b/polla_app/scraper.py
@@ -195,7 +195,7 @@ class PollaScraper:
         stop=tenacity.stop_after_attempt(3),
         before_sleep=lambda retry_state: logging.getLogger("polla_app.scraper").info(
             "Retrying scrape in %.1f seconds (attempt %d)...",
-            retry_state.next_action.sleep,
+            retry_state.next_action.sleep if retry_state.next_action else 0,
             retry_state.attempt_number,
         ),
     )


### PR DESCRIPTION
## Summary
- guard tenacity before_sleep callback against missing next_action
- annotate Playwright response logging and async context manager exit
- validate Google credential types and ensure Sheets service initialization

## Testing
- `ruff check polla_app/browser.py polla_app/sheets.py polla_app/scraper.py`
- `mypy polla_app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21b0c8f748328bc25939b69eef1b9