### PR TITLE
Ensure scrape job only runs on successful tests

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -62,7 +62,7 @@ jobs:
   scrape:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: ${{ success() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- require successful tests before running scrape job

## Testing
- `pytest tests -q`
- `./bin/act workflow_dispatch -j scrape -W .github/workflows/scrape.yml` *(fails: no Docker daemon / interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a220978f048328bfe8e89791f09acc