### PR TITLE
Ensure scrape job runs on manual workflow trigger

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -62,7 +62,7 @@ jobs:
   scrape:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ success() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ needs.test.result == 'success' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- fix `scrape` workflow job condition to run on manual triggers when tests pass

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a22a2edf1083288c7fdcde2221ba28