### PR TITLE
Fix Black formatting for __main__ entrypoint

### DIFF
--- a/polla_app/__main__.py
+++ b/polla_app/__main__.py
@@ -4,4 +4,3 @@ from .cli import cli
 
 if __name__ == "__main__":  # pragma: no cover
     cli()
-


### PR DESCRIPTION
## Summary
- ensure polla_app/__main__.py matches Black's expected formatting so the formatting workflow succeeds

## Testing
- black --check polla_app/__main__.py

------
https://chatgpt.com/codex/tasks/task_e_68d78425f4c0832f8b39365249df5091