### PR TITLE
Implement alt-source pipeline and CI automation

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,10 +1,17 @@
-name: Scrape Polla.cl Prizes
+name: Ingest Alternative Sources
 
 on:
   schedule:
     # Run daily at 10:00 AM Chile time (13:00 UTC)
     - cron: '0 13 * * *'
-  workflow_dispatch:  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip publishing to Google Sheets'
+        required: false
+        default: 'false'
+  repository_dispatch:
+    types: [refresh-alt-sources]
   push:
     branches: [main]
     paths:
@@ -18,97 +25,174 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-      
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'requirements-dev.txt'
+
       - name: Install dependencies
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-      
-      - name: Install Playwright
-        run: |
-          python -m playwright install chromium
-          python -m playwright install-deps
-      
-      - name: Run linting
+
+      - name: Run formatting & linting
         run: |
           black --check polla_app tests
           ruff check polla_app tests
-      
+
       - name: Run type checking
         run: mypy polla_app
-      
+
       - name: Run tests
         run: pytest tests -v --cov=polla_app --cov-report=xml
-      
+
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
 
-  scrape:
+  ingest:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ needs.test.result == 'success' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-    
+    if: ${{ needs.test.result == 'success' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') }}
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-      
-      - name: Cache dependencies
-        uses: actions/cache@v3
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'requirements.txt'
+
+      - name: Restore pipeline state
+        id: restore-state
+        uses: actions/cache/restore@v3
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          path: pipeline_state
+          key: pipeline-state-${{ github.ref_name }}-${{ github.run_number }}
           restore-keys: |
-            ${{ runner.os }}-pip-
-      
+            pipeline-state-${{ github.ref_name }}-
+
       - name: Install dependencies
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
           pip install -r requirements.txt
-      
-      - name: Install Playwright
-        run: |
-          python -m playwright install chromium
-          python -m playwright install-deps
-      
-      - name: Run scraper
+
+      - name: Run alternative-source pipeline
+        id: pipeline
         env:
-          CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+          ALT_SOURCE_URLS: ${{ vars.ALT_SOURCE_URLS }}
+          ALT_SOURCES_API_KEYS: ${{ secrets.ALT_SOURCES_API_KEYS }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SHEETS_CREDENTIALS }}
+          GOOGLE_SPREADSHEET_ID: ${{ secrets.GOOGLE_SPREADSHEET_ID }}
         run: |
-          python -m polla_app scrape --log-level INFO
-        continue-on-error: true
-      
-      - name: Upload logs
+          mkdir -p artifacts raw pipeline_state logs
+          python -m polla_app run \
+            --sources all \
+            --retries 3 \
+            --timeout 30 \
+            --fail-fast=false \
+            --raw-dir artifacts/raw \
+            --normalized artifacts/normalized.jsonl \
+            --comparison-report artifacts/comparison_report.json \
+            --summary artifacts/run_summary.json \
+            --state-file pipeline_state/last_run.jsonl \
+            --log-file logs/run.jsonl \
+            --mismatch-threshold 0.2
+
+      - name: Parse publish decision
+        id: decision
+        run: |
+          python - <<'PY'
+          import json, pathlib, os
+          payload = json.loads(pathlib.Path('artifacts/run_summary.json').read_text())
+          value = 'true' if payload.get('publish') else 'false'
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as handle:
+              handle.write(f"publish={value}\n")
+          PY
+
+      - name: Save pipeline state
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: pipeline_state
+          key: pipeline-state-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Upload pipeline artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: scraper-logs
-          path: logs/
+          name: alt-sources-artifacts
+          path: |
+            artifacts/
+            logs/
           retention-days: 30
-      
-      - name: Upload screenshots
-        if: always()
-        uses: actions/upload-artifact@v4
+
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          python - <<'PY'
+          import json, os, urllib.request
+          webhook = os.environ.get('SLACK_WEBHOOK_URL')
+          if not webhook:
+              raise SystemExit(0)
+          payload = {
+              "text": f"Alt-sources ingestion failed for run {os.environ.get('GITHUB_RUN_ID')}"
+          }
+          req = urllib.request.Request(
+              webhook,
+              data=json.dumps(payload).encode('utf-8'),
+              headers={'Content-Type': 'application/json'},
+          )
+          urllib.request.urlopen(req)
+          PY
+
+    outputs:
+      publish: ${{ steps.decision.outputs.publish }}
+
+  publish:
+    needs: ingest
+    if: needs.ingest.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          name: debug-screenshots
-          path: debug/
-          retention-days: 7
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'requirements.txt'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: alt-sources-artifacts
+          path: artifacts
+
+      - name: Publish to Google Sheets
+        env:
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SHEETS_CREDENTIALS }}
+          GOOGLE_SPREADSHEET_ID: ${{ secrets.GOOGLE_SPREADSHEET_ID }}
+        run: |
+          DRY_RUN="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}"
+          python -m polla_app publish \
+            --normalized artifacts/normalized.jsonl \
+            --comparison-report artifacts/comparison_report.json \
+            --summary artifacts/run_summary.json \
+            --worksheet "Normalized" \
+            --discrepancy-tab "Discrepancies" \
+            --dry-run=${DRY_RUN}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,12 +1,17 @@
-name: Update Prizes
+name: Alt Sources Dry Run
 
 on:
   schedule:
-    - cron: '0 2 * * *'  # Run at 2 AM UTC daily
-  workflow_dispatch:  # Allow manual triggers
+    - cron: '0 2 * * *'  # Supplemental early-morning verification
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip publishing (always true for this workflow)'
+        required: false
+        default: 'true'
 
 jobs:
-  update-prizes:
+  dry-run:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,39 +24,59 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'requirements.txt'
 
-      - name: Install Chrome
-        run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-stable
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --no-cache-dir -r requirements.txt
+          pip install -r requirements.txt
 
-      - name: Run script
+      - name: Restore pipeline state
+        id: restore-state
+        uses: actions/cache/restore@v3
+        with:
+          path: pipeline_state
+          key: dry-run-state-${{ github.ref_name }}-${{ github.run_number }}
+          restore-keys: |
+            dry-run-state-${{ github.ref_name }}-
+
+      - name: Execute dry-run pipeline
         env:
-          CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-          PROXY_API_URL: ${{ secrets.PROXY_API_URL }}
-          PROXY_API_TOKEN: ${{ secrets.PROXY_API_TOKEN }}
-        run: python -u main.py
-        timeout-minutes: 5
-
-      - name: List workspace files (debug)
-        if: always()
-        run: ls -la
-
-      - name: Show log file content
-        if: always()
+          ALT_SOURCE_URLS: ${{ vars.ALT_SOURCE_URLS }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SHEETS_CREDENTIALS }}
         run: |
-          echo "----- LOG FILE CONTENT -----"
-          cat logs/*.log
+          mkdir -p artifacts pipeline_state logs
+          python -m polla_app run \
+            --sources all \
+            --retries 2 \
+            --timeout 25 \
+            --fail-fast=false \
+            --raw-dir artifacts/raw \
+            --normalized artifacts/normalized.jsonl \
+            --comparison-report artifacts/comparison_report.json \
+            --summary artifacts/run_summary.json \
+            --state-file pipeline_state/last_run.jsonl \
+            --log-file logs/run.jsonl \
+            --mismatch-threshold 0.3 \
+            --include-pozos
+          python -m polla_app publish \
+            --normalized artifacts/normalized.jsonl \
+            --comparison-report artifacts/comparison_report.json \
+            --summary artifacts/run_summary.json \
+            --worksheet "Normalized" \
+            --discrepancy-tab "Discrepancies" \
+            --dry-run
 
-      - name: Upload debug screenshot artifacts
+      - name: Save pipeline state
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: pipeline_state
+          key: dry-run-state-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Upload dry-run artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: debug-screenshots
-          path: "*_failure_*.png"
+          name: dry-run-artifacts
+          path: |
+            artifacts/
+            logs/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ coverage.xml
 .coverage
 debug/
 logs/
+artifacts/
+pipeline_state/
 storage_state.json
 
 # Node modules for Playwright dependencies (if any)

--- a/polla_app/__init__.py
+++ b/polla_app/__init__.py
@@ -4,6 +4,8 @@ __version__ = "3.0.0"
 
 from .exceptions import ScriptError
 from .ingest import ingest_draw, list_24h_result_urls
+from .pipeline import run_pipeline
+from .publish import publish_to_google_sheets
 from .sources import (
     get_pozo_openloto,
     get_pozo_resultadosloto,
@@ -15,6 +17,8 @@ __all__ = [
     "ScriptError",
     "ingest_draw",
     "list_24h_result_urls",
+    "run_pipeline",
+    "publish_to_google_sheets",
     "parse_t13_draw",
     "parse_24h_draw",
     "get_pozo_openloto",

--- a/polla_app/__main__.py
+++ b/polla_app/__main__.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+from pathlib import Path
 
 import click
 
 from .ingest import ingest_draw, list_24h_result_urls
+from .pipeline import run_pipeline
+from .publish import publish_to_google_sheets
 from .sources import get_pozo_openloto, get_pozo_resultadosloto
 
 LOG_FORMAT = "%(asctime)s - %(levelname)s - [%(name)s] - %(message)s"
@@ -82,6 +86,209 @@ def pozos() -> None:
         "resultadoslotochile": get_pozo_resultadosloto(),
     }
     _echo_json(results)
+
+
+@cli.command()
+@click.option(
+    "--sources",
+    default="all",
+    show_default=True,
+    help="Comma-separated list of sources to use (or 'all').",
+)
+@click.option(
+    "--source-url",
+    multiple=True,
+    help="Override a source URL in the form source=url. Can be provided multiple times.",
+)
+@click.option("--retries", default=3, show_default=True, help="Number of retries per source.")
+@click.option("--timeout", default=30, show_default=True, help="HTTP timeout in seconds.")
+@click.option(
+    "--fail-fast/--no-fail-fast",
+    default=False,
+    show_default=True,
+    help="Abort on the first source failure instead of continuing.",
+)
+@click.option(
+    "--raw-dir",
+    default="artifacts/raw",
+    show_default=True,
+    help="Directory where per-source raw outputs will be written.",
+)
+@click.option(
+    "--normalized",
+    default="artifacts/normalized.jsonl",
+    show_default=True,
+    help="Path to the normalized NDJSON output file.",
+)
+@click.option(
+    "--comparison-report",
+    default="artifacts/comparison_report.json",
+    show_default=True,
+    help="Path to the comparison report JSON file.",
+)
+@click.option(
+    "--summary",
+    default="artifacts/run_summary.json",
+    show_default=True,
+    help="Path to the machine-readable run summary.",
+)
+@click.option(
+    "--state-file",
+    default="pipeline_state/last_run.jsonl",
+    show_default=True,
+    help="File used to persist the last successful normalized record.",
+)
+@click.option(
+    "--log-file",
+    default="logs/run.jsonl",
+    show_default=True,
+    help="Structured log file emitted by the pipeline.",
+)
+@click.option(
+    "--mismatch-threshold",
+    default=0.25,
+    show_default=True,
+    help="Maximum ratio of category mismatches tolerated before quarantining output.",
+)
+@click.option(
+    "--include-pozos/--no-include-pozos",
+    default=True,
+    show_default=True,
+    help="Include próximo pozo enrichment in the normalized record.",
+)
+def run(
+    sources: str,
+    source_url: tuple[str, ...],
+    retries: int,
+    timeout: int,
+    fail_fast: bool,
+    raw_dir: str,
+    normalized: str,
+    comparison_report: str,
+    summary: str,
+    state_file: str,
+    log_file: str,
+    mismatch_threshold: float,
+    include_pozos: bool,
+) -> None:
+    """Execute the multi-source ingestion pipeline."""
+
+    if retries < 1:
+        raise click.BadParameter("--retries must be >= 1")
+    if timeout < 1:
+        raise click.BadParameter("--timeout must be >= 1")
+    if mismatch_threshold < 0:
+        raise click.BadParameter("--mismatch-threshold must be >= 0")
+
+    requested_sources = [item.strip() for item in sources.split(",") if item.strip()]
+    if not requested_sources:
+        requested_sources = ["all"]
+
+    overrides: dict[str, str] = {}
+    env_overrides = os.getenv("ALT_SOURCE_URLS")
+    if env_overrides:
+        try:
+            data = json.loads(env_overrides)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter("ALT_SOURCE_URLS must contain valid JSON") from exc
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if isinstance(key, str) and isinstance(value, str):
+                    overrides.setdefault(key.lower(), value)
+    for item in source_url:
+        if "=" not in item:
+            raise click.BadParameter("--source-url must be in the format source=url")
+        key, value = item.split("=", 1)
+        key = key.strip().lower()
+        if not key or not value:
+            raise click.BadParameter("--source-url must include a non-empty source and url")
+        overrides[key] = value.strip()
+
+    summary_payload = run_pipeline(
+        sources=requested_sources,
+        source_overrides=overrides,
+        raw_dir=Path(raw_dir),
+        normalized_path=Path(normalized),
+        comparison_report_path=Path(comparison_report),
+        summary_path=Path(summary),
+        state_path=Path(state_file),
+        log_path=Path(log_file),
+        retries=retries,
+        timeout=timeout,
+        fail_fast=fail_fast,
+        mismatch_threshold=mismatch_threshold,
+        include_pozos=include_pozos,
+    )
+
+    _echo_json(summary_payload)
+
+
+@cli.command()
+@click.option("--normalized", required=True, help="Path to the normalized NDJSON file.")
+@click.option("--comparison-report", required=True, help="Path to the comparison report JSON file.")
+@click.option(
+    "--summary",
+    default=None,
+    help="Optional run summary JSON file to honour publish/quarantine decisions.",
+)
+@click.option(
+    "--worksheet",
+    default="Normalized",
+    show_default=True,
+    help="Worksheet name to update with canonical data.",
+)
+@click.option(
+    "--discrepancy-tab",
+    default="Discrepancies",
+    show_default=True,
+    help="Worksheet name used to store comparison mismatches.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    show_default=True,
+    help="Skip calls to the Google Sheets API and only print the intended actions.",
+)
+@click.option(
+    "--force-publish/--no-force-publish",
+    default=False,
+    show_default=True,
+    help="Publish even if the run summary requested quarantine.",
+)
+@click.option(
+    "--allow-quarantine/--no-allow-quarantine",
+    default=False,
+    show_default=True,
+    help="When set, discrepancies are still written even if the canonical update is skipped.",
+)
+def publish(
+    normalized: str,
+    comparison_report: str,
+    summary: str | None,
+    worksheet: str,
+    discrepancy_tab: str,
+    dry_run: bool,
+    force_publish: bool,
+    allow_quarantine: bool,
+) -> None:
+    """Publish validated data to Google Sheets."""
+
+    summary_payload: dict[str, object] | None = None
+    if summary:
+        summary_payload = json.loads(Path(summary).read_text(encoding="utf-8"))
+
+    result = publish_to_google_sheets(
+        normalized_path=Path(normalized),
+        comparison_report_path=Path(comparison_report),
+        summary=summary_payload,
+        worksheet_name=worksheet,
+        discrepancy_tab=discrepancy_tab,
+        dry_run=dry_run,
+        force_publish=force_publish,
+        allow_quarantine=allow_quarantine,
+    )
+
+    _echo_json(result)
 
 
 if __name__ == "__main__":

--- a/polla_app/pipeline.py
+++ b/polla_app/pipeline.py
@@ -1,0 +1,476 @@
+"""End-to-end orchestration for the alternative-source ingestion workflow."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections import Counter
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .net import FetchMetadata, fetch_html
+from .sources import _24h as source_24h
+from .sources import pozos as pozos_module
+from .sources import t13 as source_t13
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SourceResult:
+    """Result of parsing a single source."""
+
+    name: str
+    url: str
+    metadata: FetchMetadata
+    record: dict[str, Any]
+
+
+SourceLoader = Callable[[str, int], SourceResult]
+
+
+def _load_t13(url: str, timeout: int) -> SourceResult:
+    metadata = fetch_html(url, ua=source_t13.DEFAULT_UA, timeout=timeout)
+    record = source_t13.parse_draw_from_metadata(metadata, source="t13")
+    if not record.get("premios"):
+        raise RuntimeError(f"No se encontraron premios en {url}")
+    return SourceResult(name="t13", url=url, metadata=metadata, record=record)
+
+
+def _load_24h(url: str, timeout: int) -> SourceResult:
+    metadata = fetch_html(url, ua=source_24h.DEFAULT_UA, timeout=timeout)
+    record = source_t13.parse_draw_from_metadata(metadata, source="24horas")
+    if not record.get("premios"):
+        LOGGER.debug("Retrying %s with T13 user-agent after empty premio list", url)
+        metadata = fetch_html(url, ua=source_t13.DEFAULT_UA, timeout=timeout)
+        record = source_t13.parse_draw_from_metadata(metadata, source="24horas")
+    if not record.get("premios"):
+        raise RuntimeError(f"No se encontraron premios en {url}")
+    return SourceResult(name="24h", url=url, metadata=metadata, record=record)
+
+
+SOURCE_LOADERS: dict[str, SourceLoader] = {
+    "t13": _load_t13,
+    "24h": _load_24h,
+}
+
+
+def _normalise_sources(requested: Sequence[str]) -> list[str]:
+    if "all" in {item.lower() for item in requested}:
+        return sorted(SOURCE_LOADERS.keys())
+    normalised: list[str] = []
+    for item in requested:
+        key = item.lower()
+        if key not in SOURCE_LOADERS:
+            raise ValueError(f"Unsupported source '{item}'. Available: {', '.join(SOURCE_LOADERS)}")
+        if key not in normalised:
+            normalised.append(key)
+    return normalised
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: Iterable[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False))
+            handle.write("\n")
+
+
+def _save_raw_outputs(raw_dir: Path, result: SourceResult) -> None:
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    html_path = raw_dir / f"{result.name}.html"
+    html_path.write_text(result.metadata.html, encoding="utf-8")
+    json_path = raw_dir / f"{result.name}.json"
+    json_path.write_text(json.dumps(result.record, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _category_map(record: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    mapping: dict[str, dict[str, Any]] = {}
+    for item in record.get("premios", []) or []:
+        categoria = item.get("categoria")
+        if categoria:
+            mapping[categoria] = {
+                "premio_clp": item.get("premio_clp", 0),
+                "ganadores": item.get("ganadores", 0),
+            }
+    return mapping
+
+
+def _build_consensus(records: dict[str, dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], float]:
+    categories: set[str] = set()
+    for data in records.values():
+        categories.update(data.keys())
+
+    mismatches: list[dict[str, Any]] = []
+    consensus_rows: list[dict[str, Any]] = []
+
+    for categoria in sorted(categories):
+        values: dict[str, tuple[int, int]] = {}
+        for source_name, source_rows in records.items():
+            if categoria in source_rows:
+                row = source_rows[categoria]
+                values[source_name] = (int(row.get("premio_clp", 0)), int(row.get("ganadores", 0)))
+
+        if not values:
+            continue
+
+        counter = Counter(values.values())
+        majority_value, count = counter.most_common(1)[0]
+        consensus_rows.append(
+            {
+                "categoria": categoria,
+                "premio_clp": majority_value[0],
+                "ganadores": majority_value[1],
+            }
+        )
+
+        disagreeing = {
+            source: {"premio_clp": val[0], "ganadores": val[1]}
+            for source, val in values.items()
+            if val != majority_value
+        }
+        missing_sources = [src for src in records if src not in values]
+
+        if disagreeing or missing_sources:
+            mismatches.append(
+                {
+                    "categoria": categoria,
+                    "consensus": {
+                        "premio_clp": majority_value[0],
+                        "ganadores": majority_value[1],
+                        "support": count,
+                    },
+                    "disagreeing": disagreeing,
+                    "missing_sources": missing_sources,
+                }
+            )
+
+    mismatch_ratio = 0.0
+    if consensus_rows:
+        mismatch_ratio = len(mismatches) / len(consensus_rows)
+
+    return consensus_rows, mismatches, mismatch_ratio
+
+
+def _load_previous_state(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    previous: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                previous.append(json.loads(line))
+            except json.JSONDecodeError:
+                LOGGER.warning("Invalid JSON line in %s; ignoring", path)
+    return previous
+
+
+def _compare_with_previous(current: dict[str, Any], previous: Iterable[dict[str, Any]]) -> bool:
+    """Return True if prizes changed compared to the last known record."""
+
+    current_sorteo = current.get("sorteo")
+    if current_sorteo is None:
+        return True
+
+    def _normalise_prizes(record: Mapping[str, Any]) -> list[tuple[str, int, int]]:
+        rows = [
+            (
+                item.get("categoria", ""),
+                int(item.get("premio_clp", 0)),
+                int(item.get("ganadores", 0)),
+            )
+            for item in record.get("premios", []) or []
+        ]
+        return sorted(rows)
+
+    for candidate in previous:
+        if candidate.get("sorteo") != current_sorteo:
+            continue
+        if _normalise_prizes(candidate) == _normalise_prizes(current):
+            return False
+    return True
+
+
+def _collect_pozos(include: bool) -> tuple[dict[str, Any], ...]:
+    if not include:
+        return tuple()
+
+    collected: list[dict[str, Any]] = []
+    for fetcher in (pozos_module.get_pozo_openloto, pozos_module.get_pozo_resultadosloto):
+        try:
+            payload = fetcher()
+        except Exception as exc:  # pragma: no cover - network/runtime guard
+            LOGGER.warning("Pozo fetcher %s failed: %s", fetcher.__name__, exc)
+            continue
+        if payload.get("montos"):
+            collected.append(payload)
+    return tuple(collected)
+
+
+def _merge_pozos(collected: Iterable[dict[str, Any]]) -> tuple[dict[str, Any], dict[str, Any]]:
+    merged: dict[str, int] = {}
+    provenance: dict[str, Any] = {}
+    alternatives: list[dict[str, Any]] = []
+    for idx, entry in enumerate(collected):
+        for categoria, monto in entry.get("montos", {}).items():
+            merged.setdefault(categoria, int(monto))
+        descriptor = {
+            "fuente": entry.get("fuente"),
+            "fetched_at": entry.get("fetched_at"),
+            "user_agent": entry.get("user_agent"),
+            "estimado": entry.get("estimado", True),
+        }
+        if idx == 0:
+            provenance["primary"] = descriptor
+        else:
+            alternatives.append(descriptor)
+    if alternatives:
+        provenance["alternatives"] = alternatives
+    return merged, provenance
+
+
+def _init_log_stream(log_path: Path) -> Callable[[dict[str, Any]], None]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = log_path.open("a", encoding="utf-8")
+
+    def _emit(payload: dict[str, Any]) -> None:
+        payload = dict(payload)
+        payload.setdefault("timestamp", datetime.now(timezone.utc).isoformat())
+        handle.write(json.dumps(payload, ensure_ascii=False))
+        handle.write("\n")
+        handle.flush()
+
+    def _close() -> None:
+        handle.close()
+
+    _emit.close = _close  # type: ignore[attr-defined]
+    return _emit
+
+
+def run_pipeline(
+    *,
+    sources: Sequence[str],
+    source_overrides: Mapping[str, str] | None,
+    raw_dir: Path,
+    normalized_path: Path,
+    comparison_report_path: Path,
+    summary_path: Path,
+    state_path: Path,
+    log_path: Path,
+    retries: int,
+    timeout: int,
+    fail_fast: bool,
+    mismatch_threshold: float,
+    include_pozos: bool,
+) -> dict[str, Any]:
+    """Run the ingestion + validation pipeline and emit artefacts."""
+
+    log_event = _init_log_stream(log_path)
+    run_id = str(uuid.uuid4())
+    log_event({"event": "pipeline_start", "run_id": run_id, "sources": sources})
+
+    try:
+        requested_sources = _normalise_sources(sources)
+        overrides = {k.lower(): v for k, v in (source_overrides or {}).items()}
+
+        results: list[SourceResult] = []
+        failures: list[dict[str, Any]] = []
+
+        for source_name in requested_sources:
+            loader = SOURCE_LOADERS[source_name]
+            url = overrides.get(source_name)
+            if not url and source_name == "24h":
+                discovered = source_24h.list_24h_result_urls(limit=1, timeout=timeout)
+                if discovered:
+                    url = discovered[0]
+            if not url:
+                raise RuntimeError(f"No URL configured for source '{source_name}'")
+
+            attempt = 0
+            while True:
+                try:
+                    result = loader(url, timeout)
+                except Exception as exc:  # pragma: no cover - retry logic
+                    attempt += 1
+                    log_event(
+                        {
+                            "event": "source_error",
+                            "source": source_name,
+                            "url": url,
+                            "attempt": attempt,
+                            "message": str(exc),
+                        }
+                    )
+                    if attempt >= retries:
+                        failures.append({"source": source_name, "url": url, "error": str(exc)})
+                        if fail_fast:
+                            raise
+                        break
+                    time.sleep(min(2 * attempt, 10))
+                    continue
+                else:
+                    log_event(
+                        {
+                            "event": "source_success",
+                            "source": source_name,
+                            "url": url,
+                            "sorteo": result.record.get("sorteo"),
+                            "premio_rows": len(result.record.get("premios", []) or []),
+                        }
+                    )
+                    results.append(result)
+                    break
+
+        if not results:
+            raise RuntimeError("No valid sources were collected; aborting run")
+
+        for result in results:
+            _save_raw_outputs(raw_dir, result)
+
+        category_views = {item.name: _category_map(item.record) for item in results}
+        consensus_rows, mismatches, mismatch_ratio = _build_consensus(category_views)
+
+        if not consensus_rows:
+            raise RuntimeError("No prize categories available after parsing all sources")
+
+        last_draw = {
+            "sorteo": max((res.record.get("sorteo") or 0) for res in results),
+            "fecha": None,
+        }
+        fechas = [res.record.get("fecha") for res in results if res.record.get("fecha")]
+        if fechas:
+            last_draw["fecha"] = max(fechas)
+
+        selected_source = results[0]
+        consensus_record: dict[str, Any] = {
+            "sorteo": last_draw["sorteo"],
+            "fecha": last_draw["fecha"],
+            "fuente": selected_source.url,
+            "premios": consensus_rows,
+            "provenance": {
+                "run_id": run_id,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "sources": [
+                    {
+                        "source": item.name,
+                        "url": item.url,
+                        "html_sha256": item.metadata.sha256,
+                        "fetched_at": item.metadata.fetched_at.isoformat(),
+                        "user_agent": item.metadata.user_agent,
+                    }
+                    for item in results
+                ],
+            },
+        }
+
+        if include_pozos:
+            collected = _collect_pozos(include=True)
+            if collected:
+                merged_pozos, pozos_prov = _merge_pozos(collected)
+                if merged_pozos:
+                    consensus_record["pozos_proximo"] = merged_pozos
+                    consensus_record["provenance"]["pozos"] = pozos_prov
+
+        previous_records = _load_previous_state(state_path)
+        prizes_changed = _compare_with_previous(consensus_record, previous_records)
+
+        _write_jsonl(normalized_path, [consensus_record])
+        _write_json(summary_path, {"status": "pending"})  # overwritten below
+
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_jsonl(state_path, [consensus_record])
+
+        total_categories = len(consensus_rows)
+        mismatch_count = len(mismatches)
+
+        if mismatch_count == 0:
+            decision = {"status": "publish", "reason": "No mismatches detected"}
+        elif mismatch_ratio <= mismatch_threshold:
+            decision = {
+                "status": "publish_with_warnings",
+                "reason": "Minor mismatches tolerated",
+                "mismatch_ratio": mismatch_ratio,
+            }
+        else:
+            decision = {
+                "status": "quarantine",
+                "reason": "Mismatch ratio exceeds threshold",
+                "mismatch_ratio": mismatch_ratio,
+            }
+
+        report_payload = {
+            "run": {
+                "id": run_id,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "sources": requested_sources,
+                "timeout": timeout,
+                "retries": retries,
+                "fail_fast": fail_fast,
+            },
+            "last_draw": last_draw,
+            "decision": {
+                **decision,
+                "total_categories": total_categories,
+                "mismatched_categories": mismatch_count,
+            },
+            "prizes_changed": prizes_changed,
+            "mismatches": mismatches,
+            "sources": {
+                item.name: {
+                    "url": item.url,
+                    "sorteo": item.record.get("sorteo"),
+                    "fecha": item.record.get("fecha"),
+                    "premios": len(item.record.get("premios", []) or []),
+                }
+                for item in results
+            },
+            "failures": failures,
+        }
+
+        _write_json(comparison_report_path, report_payload)
+
+        summary_payload = {
+            "run_id": run_id,
+            "generated_at": report_payload["run"]["generated_at"],
+            "decision": report_payload["decision"],
+            "prizes_changed": prizes_changed,
+            "normalized_path": str(normalized_path),
+            "comparison_report": str(comparison_report_path),
+            "raw_dir": str(raw_dir),
+            "state_path": str(state_path),
+            "publish": report_payload["decision"]["status"].startswith("publish"),
+        }
+
+        _write_json(summary_path, summary_payload)
+
+        log_event(
+            {
+                "event": "pipeline_complete",
+                "run_id": run_id,
+                "decision": summary_payload["decision"]["status"],
+                "mismatch_ratio": mismatch_ratio,
+                "prizes_changed": prizes_changed,
+            }
+        )
+
+        return summary_payload
+    finally:
+        closer = getattr(log_event, "close", None)
+        if callable(closer):  # pragma: no branch - trivial guard
+            closer()
+
+
+__all__ = ["run_pipeline", "SOURCE_LOADERS", "SourceResult"]

--- a/polla_app/publish.py
+++ b/polla_app/publish.py
@@ -1,0 +1,167 @@
+"""Utilities to publish validated data to Google Sheets."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import gspread
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _load_credentials() -> gspread.Client:
+    raw = (Path.cwd() / "service_account.json")
+    credentials_env = None
+    if raw.exists():  # pragma: no cover - developer override
+        credentials_env = raw.read_text(encoding="utf-8")
+    if credentials_env is None:
+        credentials_env = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
+    if not credentials_env:
+        raise RuntimeError("GOOGLE_SERVICE_ACCOUNT_JSON environment variable is required")
+    try:
+        payload = json.loads(credentials_env)
+    except json.JSONDecodeError as exc:  # pragma: no cover - misconfiguration guard
+        raise RuntimeError("Invalid GOOGLE_SERVICE_ACCOUNT_JSON payload") from exc
+    return gspread.service_account_from_dict(payload)
+
+
+def _normalise_summary(summary: dict[str, Any] | None) -> dict[str, Any]:
+    return summary or {}
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _record_to_rows(record: dict[str, Any]) -> list[list[Any]]:
+    pozos = json.dumps(record.get("pozos_proximo", {}), ensure_ascii=False)
+    provenance = json.dumps(record.get("provenance", {}), ensure_ascii=False)
+    rows: list[list[Any]] = []
+    for premio in record.get("premios", []):
+        rows.append(
+            [
+                record.get("sorteo"),
+                record.get("fecha"),
+                record.get("fuente"),
+                premio.get("categoria"),
+                premio.get("premio_clp"),
+                premio.get("ganadores"),
+                pozos,
+                provenance,
+            ]
+        )
+    return rows
+
+
+def _mismatch_rows(report: dict[str, Any]) -> list[list[Any]]:
+    rows: list[list[Any]] = []
+    for mismatch in report.get("mismatches", []):
+        rows.append(
+            [
+                report.get("last_draw", {}).get("sorteo"),
+                mismatch.get("categoria"),
+                json.dumps(mismatch.get("consensus", {}), ensure_ascii=False),
+                json.dumps(mismatch.get("disagreeing", {}), ensure_ascii=False),
+                ", ".join(mismatch.get("missing_sources", [])),
+            ]
+        )
+    return rows
+
+
+def publish_to_google_sheets(
+    *,
+    normalized_path: Path,
+    comparison_report_path: Path,
+    summary: dict[str, Any] | None,
+    worksheet_name: str,
+    discrepancy_tab: str,
+    dry_run: bool,
+    force_publish: bool,
+    allow_quarantine: bool,
+) -> dict[str, Any]:
+    """Publish normalized data to Google Sheets."""
+
+    normalized = [json.loads(line) for line in normalized_path.read_text(encoding="utf-8").splitlines() if line]
+    if not normalized:
+        raise RuntimeError("Normalized dataset is empty; nothing to publish")
+
+    report = _load_json(comparison_report_path)
+    summary_payload = _normalise_summary(summary)
+
+    decision = report.get("decision", {})
+    status = str(decision.get("status", "")).lower()
+    publish_allowed = status.startswith("publish")
+
+    if summary_payload:
+        publish_allowed = bool(summary_payload.get("publish", publish_allowed))
+        status = str(summary_payload.get("decision", {}).get("status", status)).lower()
+
+    if not publish_allowed and not force_publish:
+        LOGGER.info("Run is quarantined; canonical worksheet will not be updated")
+    rows = _record_to_rows(normalized[0])
+    mismatch_rows = _mismatch_rows(report)
+
+    result = {
+        "updated_rows": 0,
+        "discrepancy_rows": len(mismatch_rows),
+        "status": status,
+        "publish_allowed": publish_allowed or force_publish,
+    }
+
+    if dry_run:
+        LOGGER.info("Dry-run enabled; skipping Google Sheets API calls")
+        spreadsheet_id = os.getenv("GOOGLE_SPREADSHEET_ID") or os.getenv("GOOGLE_SHEETS_SPREADSHEET_ID")
+        if spreadsheet_id:
+            result["spreadsheet_id"] = spreadsheet_id
+        result.update({"worksheet": worksheet_name, "discrepancy_tab": discrepancy_tab})
+        return result
+
+    spreadsheet_id = os.getenv("GOOGLE_SPREADSHEET_ID") or os.getenv("GOOGLE_SHEETS_SPREADSHEET_ID")
+    if not spreadsheet_id:
+        raise RuntimeError("GOOGLE_SPREADSHEET_ID environment variable is required")
+
+    client = _load_credentials()
+    spreadsheet = client.open_by_key(spreadsheet_id)
+
+    if publish_allowed or force_publish:
+        try:
+            worksheet = spreadsheet.worksheet(worksheet_name)
+        except gspread.WorksheetNotFound:
+            worksheet = spreadsheet.add_worksheet(title=worksheet_name, rows="200", cols="10")
+        worksheet.clear()
+        worksheet.update(
+            [[
+                "sorteo",
+                "fecha",
+                "fuente",
+                "categoria",
+                "premio_clp",
+                "ganadores",
+                "pozos_proximo",
+                "provenance",
+            ]] + rows
+        )
+        result["updated_rows"] = len(rows)
+
+    if mismatch_rows or allow_quarantine:
+        try:
+            discrepancy_ws = spreadsheet.worksheet(discrepancy_tab)
+        except gspread.WorksheetNotFound:
+            discrepancy_ws = spreadsheet.add_worksheet(title=discrepancy_tab, rows="200", cols="10")
+        headers = ["sorteo", "categoria", "consensus", "disagreeing", "missing_sources"]
+        payload = [headers]
+        if mismatch_rows:
+            payload.extend(mismatch_rows)
+        else:
+            payload.append([report.get("last_draw", {}).get("sorteo"), "", "", "", ""])
+        discrepancy_ws.clear()
+        discrepancy_ws.update(payload)
+
+    return result
+
+
+__all__ = ["publish_to_google_sheets"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "beautifulsoup4>=4.12.3",
     "click>=8.1.7",
     "requests>=2.32.4",
+    "gspread>=6.1.0",
+    "google-auth>=2.30.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 beautifulsoup4==4.12.3
 click==8.1.7
 requests==2.32.4
+gspread==6.1.0
+google-auth==2.30.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from polla_app.net import FetchMetadata
+from polla_app.pipeline import SOURCE_LOADERS, SourceResult, run_pipeline
+
+
+@pytest.fixture
+def fake_metadata() -> FetchMetadata:
+    return FetchMetadata(
+        url="https://example.test/t13",
+        user_agent="pytest",
+        fetched_at=datetime(2024, 12, 1, tzinfo=timezone.utc),
+        html="<html></html>",
+    )
+
+
+def _make_record(premio_value: int) -> dict[str, object]:
+    return {
+        "sorteo": 5198,
+        "fecha": "2024-12-01",
+        "fuente": "https://example.test/t13",
+        "premios": [
+            {"categoria": "Loto 6 aciertos", "premio_clp": premio_value, "ganadores": 0},
+            {"categoria": "Terna", "premio_clp": 1000, "ganadores": 10},
+        ],
+    }
+
+
+def test_pipeline_produces_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_metadata: FetchMetadata) -> None:
+    source_results = {
+        "t13": SourceResult("t13", "https://example.test/t13", fake_metadata, _make_record(0)),
+        "24h": SourceResult("24h", "https://example.test/24h", fake_metadata, _make_record(0)),
+    }
+
+    for key, result in source_results.items():
+        monkeypatch.setitem(SOURCE_LOADERS, key, lambda url, timeout, result=result: result)
+
+    output = run_pipeline(
+        sources=["all"],
+        source_overrides={"t13": "https://example.test/t13", "24h": "https://example.test/24h"},
+        raw_dir=tmp_path / "raw",
+        normalized_path=tmp_path / "normalized.jsonl",
+        comparison_report_path=tmp_path / "comparison.json",
+        summary_path=tmp_path / "summary.json",
+        state_path=tmp_path / "state.jsonl",
+        log_path=tmp_path / "run.log",
+        retries=1,
+        timeout=5,
+        fail_fast=True,
+        mismatch_threshold=0.5,
+        include_pozos=False,
+    )
+
+    assert (tmp_path / "raw" / "t13.json").exists()
+    assert (tmp_path / "normalized.jsonl").exists()
+    assert (tmp_path / "comparison.json").exists()
+    assert output["publish"] is True
+
+    normalized_rows = [json.loads(line) for line in (tmp_path / "normalized.jsonl").read_text().splitlines() if line]
+    assert normalized_rows[0]["sorteo"] == 5198
+
+
+def test_pipeline_detects_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_metadata: FetchMetadata) -> None:
+    good = SourceResult("t13", "https://example.test/t13", fake_metadata, _make_record(0))
+    mismatch_record = _make_record(1000)
+    mismatch = SourceResult("24h", "https://example.test/24h", fake_metadata, mismatch_record)
+
+    monkeypatch.setitem(SOURCE_LOADERS, "t13", lambda url, timeout: good)
+    monkeypatch.setitem(SOURCE_LOADERS, "24h", lambda url, timeout: mismatch)
+
+    summary = run_pipeline(
+        sources=["t13", "24h"],
+        source_overrides={"t13": good.url, "24h": mismatch.url},
+        raw_dir=tmp_path / "raw",
+        normalized_path=tmp_path / "normalized.jsonl",
+        comparison_report_path=tmp_path / "comparison.json",
+        summary_path=tmp_path / "summary.json",
+        state_path=tmp_path / "state.jsonl",
+        log_path=tmp_path / "run.log",
+        retries=1,
+        timeout=5,
+        fail_fast=False,
+        mismatch_threshold=0.0,
+        include_pozos=False,
+    )
+
+    assert summary["decision"]["status"] == "quarantine"
+    report = json.loads((tmp_path / "comparison.json").read_text())
+    assert report["decision"]["status"] == "quarantine"
+    assert report["mismatches"], "Expected mismatches in comparison report"

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polla_app.publish import publish_to_google_sheets
+
+
+@pytest.fixture
+def normalized_file(tmp_path: Path) -> Path:
+    record = {
+        "sorteo": 5198,
+        "fecha": "2024-12-01",
+        "fuente": "https://example.test/t13",
+        "premios": [
+            {"categoria": "Loto 6 aciertos", "premio_clp": 0, "ganadores": 0},
+        ],
+    }
+    path = tmp_path / "normalized.jsonl"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def comparison_file(tmp_path: Path) -> Path:
+    payload = {
+        "decision": {"status": "publish", "total_categories": 1, "mismatched_categories": 0},
+        "mismatches": [],
+        "last_draw": {"sorteo": 5198},
+    }
+    path = tmp_path / "comparison.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_publish_dry_run(normalized_file: Path, comparison_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_SPREADSHEET_ID", "dummy")
+    result = publish_to_google_sheets(
+        normalized_path=normalized_file,
+        comparison_report_path=comparison_file,
+        summary=None,
+        worksheet_name="Normalized",
+        discrepancy_tab="Discrepancies",
+        dry_run=True,
+        force_publish=False,
+        allow_quarantine=True,
+    )
+
+    assert result["updated_rows"] == 0
+    assert result["discrepancy_rows"] == 0


### PR DESCRIPTION
## Summary
- add a reusable pipeline runner that ingests alternative sources, produces artifacts, and tracks publish decisions
- add Google Sheets publishing utilities and expose new CLI commands for running and publishing the pipeline
- rework scheduled workflows to use the new pipeline, manage cached state, and surface dry-run artifacts

## Testing
- pytest -q
- ruff check polla_app tests

------
https://chatgpt.com/codex/tasks/task_e_68d7e6aad864832f84ed00aaea154864