### PR TITLE
Fix fail-fast flag usage in workflows

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -97,7 +97,7 @@ jobs:
             --sources all \
             --retries 3 \
             --timeout 30 \
-            --fail-fast=false \
+            --no-fail-fast \
             --raw-dir artifacts/raw \
             --normalized artifacts/normalized.jsonl \
             --comparison-report artifacts/comparison_report.json \

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,7 +48,7 @@ jobs:
             --sources all \
             --retries 2 \
             --timeout 25 \
-            --fail-fast=false \
+            --no-fail-fast \
             --raw-dir artifacts/raw \
             --normalized artifacts/normalized.jsonl \
             --comparison-report artifacts/comparison_report.json \


### PR DESCRIPTION
## Summary
- replace the deprecated `--fail-fast=false` flag with the supported `--no-fail-fast` option in both workflow pipelines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f4f34cc8832fa269846761bd3acc