### PR TITLE
Handle missing source URLs gracefully

### DIFF
--- a/polla_app/pipeline.py
+++ b/polla_app/pipeline.py
@@ -299,7 +299,24 @@ def run_pipeline(
                 if discovered:
                     url = discovered[0]
             if not url:
-                raise RuntimeError(f"No URL configured for source '{source_name}'")
+                message = f"No URL configured for source '{source_name}'"
+                log_event(
+                    {
+                        "event": "source_missing_url",
+                        "source": source_name,
+                        "message": message,
+                    }
+                )
+                if fail_fast:
+                    raise RuntimeError(message)
+                failures.append(
+                    {
+                        "source": source_name,
+                        "url": None,
+                        "error": "Source skipped: missing URL",
+                    }
+                )
+                continue
 
             attempt = 0
             while True:


### PR DESCRIPTION
## Summary
- log and record missing source URLs when fail-fast mode is disabled so the pipeline can continue
- preserve fail-fast behaviour by still raising an error when a URL is missing and fail-fast is enabled
- extend pipeline tests to cover missing-URL skip and fail-fast scenarios

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68d7f8e114b8832f8a5705d44ef208ee