### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -1,4 +1,6 @@
 name: health
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/cortega26/polla/security/code-scanning/14](https://github.com/cortega26/polla/security/code-scanning/14)

To fix the issue, we should add an explicit `permissions` block to limit token access to only what this workflow needs. Given the workflow only checks out code, installs dependencies, and runs health checks (no pushes, PR changes, etc.), the minimal required permission is `contents: read`. The permission block can be placed either at the workflow root (before `jobs:`) to apply to all jobs, or under each job; here, setting at the root is simplest and clearest, as there is only one job.

Edit `.github/workflows/health.yml` by inserting the following directly after the `name:` line and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional method, import, or definition is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
