### PR TITLE
Fix publish workflow skip reason visibility

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -117,11 +117,40 @@ jobs:
         id: decision
         run: |
           python - <<'PY'
-          import json, pathlib, os
-          payload = json.loads(pathlib.Path('artifacts/run_summary.json').read_text())
-          value = 'true' if payload.get('publish') else 'false'
-          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as handle:
-              handle.write(f"publish={value}\n")
+          """Expose publish decision metadata for downstream jobs."""
+
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = Path("artifacts/run_summary.json")
+          if not summary_path.exists():
+              raise SystemExit("Run summary not found; cannot determine publish decision")
+
+          payload = json.loads(summary_path.read_text(encoding="utf-8"))
+          publish_flag = bool(payload.get("publish"))
+          decision = payload.get("decision", {}) or {}
+          status = str(decision.get("status", "unknown"))
+          reason = str(payload.get("publish_reason") or decision.get("reason") or "unknown")
+
+          outputs_path = Path(os.environ["GITHUB_OUTPUT"])
+          with outputs_path.open("a", encoding="utf-8") as handle:
+              handle.write(f"publish={'true' if publish_flag else 'false'}\n")
+              handle.write(f"publish_reason={reason}\n")
+              handle.write(f"decision_status={status}\n")
+
+          summary_output = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_output:
+              with Path(summary_output).open("a", encoding="utf-8") as handle:
+                  handle.write("### Publish decision\n")
+                  handle.write(f"- Publish: {'yes' if publish_flag else 'no'}\n")
+                  handle.write(f"- Status: {status}\n")
+                  handle.write(f"- Reason: {reason}\n")
+
+          if not publish_flag:
+              print(f"::notice::Publish job will be skipped because {reason} (status={status}).")
           PY
 
       - name: Save pipeline state
@@ -167,29 +196,40 @@ jobs:
 
   publish:
     needs: ingest
-    if: needs.ingest.outputs.publish == 'true'
+    if: needs.ingest.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Publish decision summary
+        if: ${{ needs.ingest.outputs.publish != 'true' }}
+        run: |
+          echo "Publish step skipped: ${{ needs.ingest.outputs.publish_reason || 'no reason provided' }} (status=${{ needs.ingest.outputs.decision_status || 'unknown' }})"
+          exit 0
+
       - uses: actions/checkout@v4
+        if: ${{ needs.ingest.outputs.publish == 'true' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        if: ${{ needs.ingest.outputs.publish == 'true' }}
         with:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'requirements.txt'
 
       - name: Install dependencies
+        if: ${{ needs.ingest.outputs.publish == 'true' }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Download artifacts
+        if: ${{ needs.ingest.outputs.publish == 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: alt-sources-artifacts
 
       - name: Publish to Google Sheets
+        if: ${{ needs.ingest.outputs.publish == 'true' }}
         env:
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SHEETS_CREDENTIALS }}
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,7 +14,7 @@ True
 
 - Sources: `"pozos"` (primary + fallback) or `"openloto"` (fallback only).
 - `source_overrides`: case‑insensitive mapping of `{ "openloto": url, "resultadoslotochile": url }`.
-- Returns a run summary with `publish` boolean and artifact paths.
+- Returns a run summary with `publish` boolean, `publish_reason` string, and artifact paths.
 
 Example:
 
@@ -38,6 +38,7 @@ summary = run_pipeline(
     include_pozos=True,
 )
 print(summary["publish"])  # True/False
+print(summary["publish_reason"])  # e.g. "updated_or_new_amounts"
 ```
 
 ## Publishing


### PR DESCRIPTION
## Summary
- add publish_reason metadata to the pipeline summary and comparison report so publish decisions carry an explicit reason
- surface the publish decision (status, reason, skip notice) inside the scrape workflow and only run the publish steps when needed
- document the new summary field and extend the pipeline tests to cover the different publish outcomes

## Testing
- ruff check .
- black --check .
- isort --check-only . *(fails: pre-existing import order issues in tests/test_parsers.py and polla_app/net.py)*
- mypy polla_app tests
- pytest -q
- bandit -ll -r polla_app
- pip-audit
- gitleaks detect --source . *(unavailable locally; deferred to CI)*

📊 COMPLIANCE: 8/9 rules met (Missing: R6 – gitleaks unavailable locally)
🤖 Model: gpt-5-codex-medium
✅ Backwards Compat: compatible
🧪 Tests: updated (pipeline summary reason cases)
🔐 Security: bandit clean (2 low), pip-audit flagged pip 25.2 (GHSA-4xh5-x5gv-qwph)
⚠️ Failed: R6
📝 Commit: fix(pipeline): surface publish skip reason
🔄 Deferred to CI: gitleaks detect --source .

------
https://chatgpt.com/codex/tasks/task_e_68f53186e450832fa7bf905b4bddfaee