### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,5 +1,8 @@
 name: Alt Sources Dry Run
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 2 * * *'  # Supplemental early-morning verification


### PR DESCRIPTION
Potential fix for [https://github.com/cortega26/polla/security/code-scanning/18](https://github.com/cortega26/polla/security/code-scanning/18)

To fix the problem, explicitly define a `permissions` block assigning the least privileges required for this workflow. Since the job only checks out code, caches data, runs Python, and uploads artifacts—none of which require write access to repository contents or other GitHub resources—it can safely use `contents: read` at the workflow or job level.

The best minimal fix without changing functionality is to add a top-level `permissions` block so it applies to all jobs in this workflow. In `.github/workflows/update.yml`, between the `name: Alt Sources Dry Run` line and the `on:` block, insert:

```yaml
permissions:
  contents: read
```

This documents that the workflow only needs read access to repository contents and constrains `GITHUB_TOKEN` accordingly. No imports, methods, or additional definitions are needed; this is purely a YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
